### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ A CLI tool to identify the hash type of a given hash.
 - CLI tool & library
 - Hackable
 
+## Install
+
+```shell
+gem install haiti-hash
+```
+
 ## References
 
 Homepage / Documentation: https://orange-cyberdefense.github.io/haiti/


### PR DESCRIPTION
I noticed in the TryHackMe discord that a user was having trouble installing haiti-hash and was using the wrong command or installing the wrong gem. So I figured adding a copy/pastable installation command might help future new users.